### PR TITLE
Update install-netcdf.sh

### DIFF
--- a/fedora/install-netcdf.sh
+++ b/fedora/install-netcdf.sh
@@ -9,20 +9,22 @@ export F77=gfortran
 export CC=gcc
 export CXX=g++
 
-wget ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-4.4.1.1.tar.gz
+wget ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-4.4.1.1.tar.gz  # must check for the available .tar file
 
 tar -xvf netcdf-4.4.1.1.tar.gz 
 
 rm netcdf-4.4.1.1.tar.gz 
 cd netcdf-4.4.1.1/
-mkdir &home/${USER}/opt/
+mkdir /home/${USER}/opt/
 
 mkdir /home/${USER}/opt/netcdf
-mkdir /home/${USER}/opt/netcdf/4.4.1.1
+mkdir /home/${USER}/opt/netcdf/4.4.1.1  
 
 ./configure --prefix=/home/${USER}/opt/netcdf/4.4.1.1 
 
+sudo dnf install m4
+
 make
 
-make install
-make check
+sudo make install
+sudo make check


### PR DESCRIPTION
La libreria m4 en Fedora 30 se necesitó para completar el sudo make install